### PR TITLE
Registration API (WIP)

### DIFF
--- a/registration_interface.py
+++ b/registration_interface.py
@@ -1,0 +1,15 @@
+import itk
+from abc import ABC, abstractmethod
+
+# The function signature each registration approach should provide
+
+class RegistrationMethod(ABC):
+    @abstractmethod
+    def __call__(
+          self,
+          fixed_image: itk.Image[itk.F, 3],
+          moving_image: itk.Image[itk.F, 3],
+          initial_transform: itk.Transform[itk.D, 3],
+          **kwargs
+        ) -> itk.Transform[itk.D, 3]:
+        pass

--- a/registration_interface.py
+++ b/registration_interface.py
@@ -17,3 +17,59 @@ class RegistrationMethod(ABC):
           **kwargs
         ) -> itk.Transform[itk.D, 3]:
         pass
+        
+
+"""
+my_moving_image = ...
+my_fixed_image = ...
+
+my_initial_transform = ...
+
+my_transform = registration_method(my_fixed_image, my_moving_image, my_initial_transform)
+
+# Case 1:
+
+# registration method returns the whole transform from fixed to moving
+
+my_warped_image = itk.resample_image_filter(
+    image_insp_preprocessed,
+    transform=my_transform,
+    interpolator=interpolator,
+    use_reference_image=True,
+    reference_image=my_fixed_image
+)
+
+# Case 2:
+
+# registration method returns an update to the initial transform
+
+
+final_transform = itk.CompositeTransform()
+final_transform.append_transform(my_initial_transform)
+final_transform.append_transform(my_transform)
+
+my_warped_image = itk.resample_image_filter(
+    image_insp_preprocessed,
+    transform=final_transform,
+    interpolator=interpolator,
+    use_reference_image=True,
+    reference_image=my_fixed_image
+)
+
+
+# Case 3:
+
+# registration method returns an update to the initial transform,
+# and initial transform is already composite
+
+initial_transform.append_transform(my_transform)
+
+my_warped_image = itk.resample_image_filter(
+    image_insp_preprocessed,
+    transform=initial_transform,
+    interpolator=interpolator,
+    use_reference_image=True,
+    reference_image=my_fixed_image
+)
+
+"""

--- a/registration_interface.py
+++ b/registration_interface.py
@@ -3,12 +3,16 @@ from abc import ABC, abstractmethod
 
 # The function signature each registration approach should provide
 
+FloatImage2DType = itk.Image[itk.F, 2]
+FloatImage3DType = itk.Image[itk.F, 3]
+FloatImageType = Union[Image2DType, Image3DType]
+
 class RegistrationMethod(ABC):
     @abstractmethod
     def __call__(
           self,
-          fixed_image: itk.Image[itk.F, 3],
-          moving_image: itk.Image[itk.F, 3],
+          fixed_image: FloatImageType,
+          moving_image: FloatImageType,
           initial_transform: itk.Transform[itk.D, 3],
           **kwargs
         ) -> itk.Transform[itk.D, 3]:

--- a/registration_interface.py
+++ b/registration_interface.py
@@ -34,7 +34,7 @@ final_transform.append_transform(my_initial_transform)
 final_transform.append_transform(my_transform)
 
 my_warped_image = itk.resample_image_filter(
-    image_insp_preprocessed,
+    my_moving_image,
     transform=final_transform,
     interpolator=interpolator,
     use_reference_image=True,

--- a/registration_interface.py
+++ b/registration_interface.py
@@ -33,6 +33,8 @@ final_transform = itk.CompositeTransform()
 final_transform.append_transform(my_initial_transform)
 final_transform.append_transform(my_transform)
 
+interpolator = itk.LinearInterpolateImageFunction.New(my_moving_image)
+
 my_warped_image = itk.resample_image_filter(
     my_moving_image,
     transform=final_transform,

--- a/registration_interface.py
+++ b/registration_interface.py
@@ -27,22 +27,7 @@ my_initial_transform = ...
 
 my_transform = registration_method(my_fixed_image, my_moving_image, my_initial_transform)
 
-# Case 1:
-
-# registration method returns the whole transform from fixed to moving
-
-my_warped_image = itk.resample_image_filter(
-    image_insp_preprocessed,
-    transform=my_transform,
-    interpolator=interpolator,
-    use_reference_image=True,
-    reference_image=my_fixed_image
-)
-
-# Case 2:
-
 # registration method returns an update to the initial transform
-
 
 final_transform = itk.CompositeTransform()
 final_transform.append_transform(my_initial_transform)
@@ -51,22 +36,6 @@ final_transform.append_transform(my_transform)
 my_warped_image = itk.resample_image_filter(
     image_insp_preprocessed,
     transform=final_transform,
-    interpolator=interpolator,
-    use_reference_image=True,
-    reference_image=my_fixed_image
-)
-
-
-# Case 3:
-
-# registration method returns an update to the initial transform,
-# and initial transform is already composite
-
-initial_transform.append_transform(my_transform)
-
-my_warped_image = itk.resample_image_filter(
-    image_insp_preprocessed,
-    transform=initial_transform,
     interpolator=interpolator,
     use_reference_image=True,
     reference_image=my_fixed_image


### PR DESCRIPTION
Question I'm curious about- I think we should have a fixed intensity scale and datatype for the input images. I'd vote for having the inputs always float32, normalized to [0, 1]. Does this make sense to everyone? The other option would be to have inputs always be unsigned char 0-255, or to have any type and range of input and require that methods do their own normalization.