### PR TITLE
ENH: Add workflow to deliver API documentation with Sphinx

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -1,0 +1,41 @@
+name: 'doc'
+
+on:
+  [push, pull_request]
+
+jobs:
+  sphinx-doc:
+    name: "Build HTML Documentation with Sphinx"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Update pip
+      run: |
+        python -m pip install --upgrade pip
+
+    - name: "Install Dependencies"
+      shell: bash
+      run: |
+        python -m pip install flit
+        cd src
+        flit install --deps develop
+
+    - name: "Build HTML API Documentation"
+      shell: bash
+      run: |
+        sphinx-apidoc -o tmp/apidoc src/itk_dreg --full
+        sed -i -e 's/alabaster/furo/' tmp/apidoc/conf.py
+        sphinx-build tmp/apidoc tmp/html
+
+    - name: Upload HTML artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: itk-dreg-html-docs
+        path: tmp/html/*
+
+    - uses: actions/upload-pages-artifact@v2.0.0
+      with:
+        path: tmp/html

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ examples/mydask.png
 
 data/
 _build/
-test/tmp/
+tmp/

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -53,6 +53,12 @@ dev = [
     'pytest'
 ]
 
+doc = [
+    'sphinx>=7.2.6',
+    'sphinx-autobuild',
+    'furo'
+]
+
 impl = [
     'itk-elastix>=0.19.0',
     'scipy>=1.11.3'


### PR DESCRIPTION
Adds GitHub Actions workflow to build API documentation with `sphinx-apidoc` and `sphinx-build` and make available as a GitHub artifact for download. HTML documentation is generated solely from Python docstrings for now, but could be expanded with a README and more descriptive content in the future.

Partially addresses https://github.com/InsightSoftwareConsortium/itk-dreg/issues/10.

See HTML artifact: https://github.com/tbirdso/itk-dreg/actions/runs/6868689278

We can follow up this PR with automated docs deployment to github.io.